### PR TITLE
CP-40: add librdkafka to debian packaging branch

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -1,5 +1,5 @@
-# This makefile assumes you have specified VERSION, SCALA_VERSION, and
-# KAFKA_VERSION. Since the package is for dependencies only and contains no
+# This makefile assumes you have specified VERSION, SCALA_VERSION, KAFKA_VERSION,
+# and LIBRDKAFKA_DEB_VERSION. Since the package is for dependencies only and contains no
 # contents, this script can be kept pretty simple.
 
 all: install
@@ -23,7 +23,7 @@ test:
 debian-control:
 	cp debian/control.in debian/control
 	for SVERSION in $(SCALA_VERSIONS); do \
-		cat debian/control.binary.in | sed -e s@##SCALAVERSION##@$$SVERSION@g -e s@##VERSION##@$$VERSION@g -e s@##KAFKAVERSION##@$$KAFKA_VERSION@g >> debian/control; \
+		cat debian/control.binary.in | sed -e s@##SCALAVERSION##@$$SVERSION@g -e s@##VERSION##@$$VERSION@g -e s@##KAFKAVERSION##@$$KAFKA_VERSION@g s@##LIBRDKAFKAVERSION##@$$LIBRDKAFKA_DEB_VERSION@g >> debian/control; \
 	done
 	git add debian/control
 	git commit -m "Add control file."

--- a/debian/control.binary.in
+++ b/debian/control.binary.in
@@ -5,7 +5,8 @@ Depends: confluent-kafka-##SCALAVERSION## (>= ##KAFKAVERSION##),
          confluent-kafka-rest (>= ##VERSION##),
          confluent-kafka-connect-hdfs (>= ##VERSION##),
          confluent-kafka-connect-jdbc (>= ##VERSION##),
-         confluent-camus (>= ##VERSION##)
+         confluent-camus (>= ##VERSION##),
+         librdkafka1 (>= ##LIBRDKAFKAVERSION##)
 Description: Confluent Platform
  The Confluent Platform is a stream data platform that leverages the proven
  capabilities of Apache Kafka to make all of your data available as realtime


### PR DESCRIPTION
@edenhill Please take a look.

Note that this PR (like the upcoming one for `rpm`) requires a change to `package.sh` in `master` to actually generate and pass the `LIBRDKAFKA_DEB_VERSION` env variable to the `Makefile`.

Given the current librdkafka and packaging code, `LIBRDKAFKA_DEB_VERSION == 0.9.0~1confluent2.0.0~SNAPSHOT-1`.